### PR TITLE
Update PyJWT version to 2.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "redis>=5.3.0",
-  "PyJWT~=2.10.0",
+  "PyJWT~=2.12.0",
   "msal~=1.33.0",
   "azure-identity~=1.24.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT~=2.10.0
+PyJWT~=2.12.0
 msal~=1.33.0
 azure-identity~=1.24.0
 redis>=5.3.0


### PR DESCRIPTION
Address https://www.tenable.com/cve/CVE-2026-32597

---

Howdy, this contribution should be low-risk, given the CVE looks to be main fix between PyJWT 2.12.0 and 2.10.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump only; behavior changes are limited to whatever upstream changes in PyJWT 2.12.0 introduce.
> 
> **Overview**
> Updates the PyJWT dependency constraint from `~=2.10.0` to `~=2.12.0` in both `pyproject.toml` and `requirements.txt` (aligning install sources and pulling in the newer PyJWT release, e.g. for security fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 810f466ece8a7c7c76f5d767eb8377cec24e778f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->