### PR TITLE
Bump PyJWT to 2.12.x to address security advisory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "redis>=5.3.0",
-  "PyJWT~=2.10.0",
+  "PyJWT~=2.12.0",
   "msal~=1.33.0",
   "azure-identity~=1.24.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT~=2.10.0
+PyJWT~=2.12.0
 msal~=1.33.0
 azure-identity~=1.24.0
 redis>=5.3.0


### PR DESCRIPTION
## Summary
- bump `PyJWT` from `~=2.10.0` to `~=2.12.0`
- update both `requirements.txt` and `pyproject.toml`
- address the PyJWT security advisory reported by GitHub

## Notes
- no application code changes
- dependency-only fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main risk is potential PyJWT behavior differences affecting token validation/encoding at runtime.
> 
> **Overview**
> Updates the `PyJWT` dependency constraint from `~=2.10.0` to `~=2.12.0` in both `pyproject.toml` and `requirements.txt` to address the reported security advisory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b97720185097a3002afe1e1fbcdbebb93acf17f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->