### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redis-entraid"
-version = "1.1.0"
+version = "1.1.2"
 authors = [
   { name="Redis Inc.", email="oss@redis.com" },
 ]


### PR DESCRIPTION
Bump version to 1.1.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version in `pyproject.toml` with no functional or dependency changes.
> 
> **Overview**
> Bumps the `redis-entraid` package version from `1.1.0` to `1.1.2` in `pyproject.toml` for a new release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 152704ea179c9070c4a08ef9aa9f36fbf3e90341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->