### PR TITLE
1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "redis>=5.3.0",
-  "PyJWT~=2.10.0",
+  "PyJWT~=2.12.0",
   "msal~=1.33.0",
   "azure-identity~=1.24.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redis-entraid"
-version = "1.1.0"
+version = "1.1.2"
 authors = [
   { name="Redis Inc.", email="oss@redis.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT~=2.10.0
+PyJWT~=2.12.0
 msal~=1.33.0
 azure-identity~=1.24.0
 redis>=5.3.0


### PR DESCRIPTION
Bump version to 1.1.2

**Changes**

- Bump PyJWT from ~=2.10.0 to ~=2.12.0 to address security advisory ([#65](https://github.com/redis/redis-py-entraid/pull/65))
- Bump package version to 1.1.2

**Details**
Cherry-picked from main:

- c33ce0e — Bump PyJWT to 2.12.x to address security advisory
- 152704e — Bump version to 1.1.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency/version bumps only, with no code or behavior changes beyond pulling in a newer PyJWT release.
> 
> **Overview**
> Bumps the package version from `1.1.0` to `1.1.2`.
> 
> Updates the `PyJWT` dependency constraint from `~=2.10.0` to `~=2.12.0` in both `pyproject.toml` and `requirements.txt` (security advisory-related).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a959aba4091bb83950b7786df8a484d780e7798f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->