### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redis-entraid"
-version = "1.1.2"
+version = "1.2.0"
 authors = [
   { name="Redis Inc.", email="oss@redis.com" },
 ]


### PR DESCRIPTION
Release 1.2.0

Highlights:
- Widened msal and azure-identity constraints to allow newer minor releases
  (fixes #62: dependency conflicts with azure-kusto-data,
  microsoft-agents-authentication-msal, and other libraries needing
  msal>=1.34 / azure-identity>=1.25).
- Declared `requests` as an explicit runtime dependency.
- Widened `requests` constraint for consistency.
- CI: dropped pypy-3.10 from the test matrix (cryptography no longer
  supports it; pypy-3.11 remains covered).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the declared package version in `pyproject.toml`, with no code or dependency changes in this diff.
> 
> **Overview**
> Bumps the `redis-entraid` package version from `1.1.2` to `1.2.0` in `pyproject.toml` for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3635a3231623e4020e0795e81b73152503aec85f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->