### PR TITLE
Bump PyJWT to 2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redis-entraid"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
   { name="Redis Inc.", email="oss@redis.com" },
 ]
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "redis>=5.3.0",
-  "PyJWT~=2.12.0",
+  "PyJWT~=2.13",
   "msal~=1.33",
   "azure-identity~=1.24",
   "requests~=2.32"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT~=2.12.0
+PyJWT~=2.13
 msal~=1.33
 azure-identity~=1.24
 redis>=5.3.0


### PR DESCRIPTION
## Summary

- Update the `PyJWT` dependency constraint from `~=2.12.0` to `~=2.13`, which allows compatible `v2` releases only and aligns with [PyJWT's explicit adherence to Semantic Versioning](https://github.com/jpadilla/pyjwt/blob/7144e4534c34810f4525dc4578a32addd8212cff/CHANGELOG.rst?plain=1#L5).
- Bump the package version from `1.2.0` to `1.2.1`.

## Notes

- No application code changes.
- Dependency-only update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version constraint and package bump only; no code paths changed.
> 
> **Overview**
> Bumps **redis-entraid** from `1.2.0` to `1.2.1` and relaxes the **PyJWT** pin from `~=2.12.0` to `~=2.13` in both `pyproject.toml` and `requirements.txt`. No library or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6ce57618ce03321d66b8c38bea7fde8d17d6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->