### PR TITLE
Bump PyJWT to 2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redis-entraid"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
   { name="Redis Inc.", email="oss@redis.com" },
 ]
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "redis>=5.3.0",
-  "PyJWT~=2.12.0",
+  "PyJWT~=2.13.0",
   "msal~=1.33",
   "azure-identity~=1.24",
   "requests~=2.32"


### PR DESCRIPTION
## Summary

- Update the `PyJWT` dependency constraint from `~=2.12.0` to `~=2.13`, which allows compatible `v2` releases only and aligns with [PyJWT's explicit adherence to Semantic Versioning](https://github.com/jpadilla/pyjwt/blob/7144e4534c34810f4525dc4578a32addd8212cff/CHANGELOG.rst?plain=1#L5).
- Bump the package version from `1.2.0` to `1.2.1`.

## Notes

- No application code changes.
- Dependency-only update.

This PR is based on  @marijnvanderhorst's PR #71 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and version metadata only; no runtime code paths change in this PR.
> 
> **Overview**
> Bumps **redis-entraid** from `1.2.0` to `1.2.1` and relaxes the **PyJWT** pin in `pyproject.toml` from `~=2.12.0` to `~=2.13.0`, so installs can pick up PyJWT 2.13.x within the existing compatible `v2` range. No library or test source changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a7dc2bb7e073c787eeb41285c1740b438c36c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->