### PR TITLE
Bumping PyJWT test dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT~=2.12.0
+PyJWT~=2.13.0
 msal~=1.33
 azure-identity~=1.24
 redis>=5.3.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency version bump with no application code changes.
> 
> **Overview**
> Bumps the **PyJWT** constraint in `requirements.txt` from `~=2.12.0` to `~=2.13.0`, keeping the same compatible-release pinning style as the rest of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96b735b8a35ca8b4b2727851eb68263f3d7b9ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->